### PR TITLE
update pin arrow functions to make arrows properly positioned

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -167,14 +167,16 @@
     end,
     callback: (start-pos, end-pos) => {
       absolute-place(
+        dx: start-pos.x + start-dx,
+        dy: start-pos.y + start-dy,
         simple-arrow(
           start: (
-            start-pos.x + start-dx,
-            start-pos.y + start-dy,
+            0em,
+            0em,
           ),
           end: (
-            end-pos.x + end-dx,
-            end-pos.y + end-dy,
+            end-pos.x + end-dx - (start-pos.x + start-dx),
+            end-pos.y + end-dy - (start-pos.y + start-dy),
           ),
           ..args,
         ),
@@ -206,14 +208,16 @@
     end,
     callback: (start-pos, end-pos) => {
       absolute-place(
+        dx: start-pos.x + start-dx,
+        dy: start-pos.y + start-dy,
         double-arrow(
           start: (
-            start-pos.x + start-dx,
-            start-pos.y + start-dy,
+            0em,
+            0em,
           ),
           end: (
-            end-pos.x + end-dx,
-            end-pos.y + end-dy,
+            end-pos.x + end-dx - (start-pos.x + start-dx),
+            end-pos.y + end-dy - (start-pos.y + start-dy),
           ),
           ..args,
         ),


### PR DESCRIPTION
MWE：
```typst
#import "@preview/touying:0.6.1": *
#import "../lib.typ": *
// #import "@preview/pinit:0.2.2": *

#import themes.stargazer: *

#show: stargazer-theme.with(
  aspect-ratio: "16-9",
  config-info(
    title: [Stargazer in Touying: Customize Your Slide Title Here],
    subtitle: [Customize Your Slide Subtitle Here],
    author: [Authors],
    date: datetime.today(),
    institution: [Institution],
    logo: emoji.school,
  ),
)

== First Slide

#slide[
  #v(100pt)
  我能吞下玻璃#pin(1)而又不伤身体

  #pinit-point-from(1)[测试]
][
  #v(200pt)
  我能吞下玻璃#pin(2)而又不伤身体

  #pinit-point-from(2, double: true)[测试]
][
  #v(300pt)
  我能吞下玻璃#pin(3)而又不伤身体

  #pinit-point-from(3)[测试]
]
```
before:
![image](https://github.com/user-attachments/assets/fe6977be-7542-410f-8b67-722a61ef905b)

after: 
![image](https://github.com/user-attachments/assets/15918fea-8d05-4317-a7b6-e9f9a3d986cb)
